### PR TITLE
Fix dialog layout issues in Visual Studio 2026

### DIFF
--- a/src/Ankh.Package/AnkhEditorFactories.cs
+++ b/src/Ankh.Package/AnkhEditorFactories.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.About.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.About.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.Win32;
 using Ankh.Configuration;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.Commands.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.Commands.cs
@@ -23,8 +23,8 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.OLE.Interop;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 using Ankh.Commands;
-using Ankh;
 using VSConstants = Microsoft.VisualStudio.VSConstants;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.Languages.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.Languages.cs
@@ -19,6 +19,7 @@ using Ankh.VS.LanguageServices.Core;
 using Ankh.VS.LanguageServices.LogMessages;
 using Ankh.VS.LanguageServices.UnifiedDiff;
 using Ankh.VSPackage.Attributes;
+using System.Linq;
 
 namespace Ankh.VSPackage
 {
@@ -51,20 +52,17 @@ namespace Ankh.VSPackage
             object obj = base.GetAutomationObject(name);
             if (obj != null || name == null)
                 return obj;
-
+            foreach (var language in
             // Look for setting objects that must be accessible by their automation name for setting persistence.
-            foreach (ProvideLanguageSettingsAttribute ps in GetType().GetCustomAttributes(typeof(ProvideLanguageSettingsAttribute), true))
+            from ProvideLanguageSettingsAttribute ps in GetType().GetCustomAttributes(typeof(ProvideLanguageSettingsAttribute), true)
+            where name == ps.Name
+            let language = GetService<AnkhLanguage>(ps.Type)
+            select language)
             {
-                if (name == ps.Name)
-                {
-                    AnkhLanguage language = GetService<AnkhLanguage>(ps.Type);
-
-                    if (language != null)
-                        obj = language.LanguagePreferences;
-
-                    if (obj != null)
-                        return obj;
-                }
+                if (language != null)
+                    obj = language.LanguagePreferences;
+                if (obj != null)
+                    return obj;
             }
 
             return null;

--- a/src/Ankh.Package/AnkhSvnPackage.OleComponent.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.OleComponent.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio;
 using System.Runtime.InteropServices;
 using Ankh.UI;
 using Ankh.VS;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.SolutionProperties.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.SolutionProperties.cs
@@ -22,6 +22,7 @@ using Ankh.Scc;
 using Ankh.Scc.Native;
 using Ankh.VS;
 using Ankh.VSPackage.Attributes;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.ToolWindows.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.ToolWindows.cs
@@ -35,6 +35,7 @@ using Ankh.UI.RepositoryExplorer;
 using Ankh.UI.SvnInfoGrid;
 using Ankh.UI.SvnLog;
 using Ankh.UI.WorkingCopyExplorer;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/AnkhSvnPackage.cs
+++ b/src/Ankh.Package/AnkhSvnPackage.cs
@@ -30,6 +30,7 @@ using Ankh.VS;
 using Ankh.UI;
 using Ankh.VSPackage.Attributes;
 using System.Collections.Generic;
+using Ankh.Services;
 
 namespace Ankh.VSPackage
 {

--- a/src/Ankh.Package/OptionPages/SolutionSettingsPage.cs
+++ b/src/Ankh.Package/OptionPages/SolutionSettingsPage.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio;
 using System.Windows.Forms;
+using Ankh.Services;
 
 namespace Ankh.VSPackage.OptionPages
 {

--- a/src/Ankh.Scc/Commands/SccCheckoutFailedProject.cs
+++ b/src/Ankh.Scc/Commands/SccCheckoutFailedProject.cs
@@ -1,5 +1,6 @@
 ﻿using Ankh.Commands;
 using Ankh.Selection;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;

--- a/src/Ankh.Scc/OpenDocumentTracker.Api.cs
+++ b/src/Ankh.Scc/OpenDocumentTracker.Api.cs
@@ -22,6 +22,7 @@ using SharpSvn;
 using System.IO;
 using System.Diagnostics;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/OpenDocumentTracker.Visibility.cs
+++ b/src/Ankh.Scc/OpenDocumentTracker.Visibility.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Ankh.Scc.ProjectMap;
 using Ankh.Selection;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/OpenDocumentTracker.cs
+++ b/src/Ankh.Scc/OpenDocumentTracker.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using SharpSvn;
 
 using Ankh.Scc.ProjectMap;
+using Ankh.Services;
 
 
 namespace Ankh.Scc

--- a/src/Ankh.Scc/ProjectNotifier.cs
+++ b/src/Ankh.Scc/ProjectNotifier.cs
@@ -26,6 +26,7 @@ using Ankh.Commands;
 using Ankh.Selection;
 using Ankh.UI;
 using Ankh.Scc.Engine;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/ProjectTracker.Add.cs
+++ b/src/Ankh.Scc/ProjectTracker.Add.cs
@@ -25,6 +25,7 @@ using SharpSvn;
 using Ankh.Commands;
 using Ankh.Selection;
 using IDataObject = System.Windows.Forms.IDataObject;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/ProjectTracker.Batching.cs
+++ b/src/Ankh.Scc/ProjectTracker.Batching.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.Scc/ProjectTracker.Remove.cs
+++ b/src/Ankh.Scc/ProjectTracker.Remove.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using SharpSvn;

--- a/src/Ankh.Scc/ProjectTracker.Rename.cs
+++ b/src/Ankh.Scc/ProjectTracker.Rename.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using SharpSvn;
 using System.IO;
 using System.Diagnostics;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/ProjectTracker.Solution.cs
+++ b/src/Ankh.Scc/ProjectTracker.Solution.cs
@@ -25,6 +25,7 @@ using Ankh.Selection;
 using Ankh.VS;
 using System.Runtime.InteropServices;
 using SharpSvn;
+using Ankh.Services;
 
 
 

--- a/src/Ankh.Scc/ProjectTracker.cs
+++ b/src/Ankh.Scc/ProjectTracker.cs
@@ -25,6 +25,7 @@ using Ankh.Configuration;
 using Ankh.VS;
 using System.ComponentModel.Design;
 using Ankh.Scc.ProjectMap;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/SccUI/ChangeSourceControl.cs
+++ b/src/Ankh.Scc/SccUI/ChangeSourceControl.cs
@@ -20,6 +20,7 @@ using System.Windows.Forms;
 using System.Windows.Forms.Design;
 
 using Ankh.Selection;
+using Ankh.Services;
 using Ankh.UI;
 using Ankh.VS;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Ankh.Scc/SccUI/Commands/ChangeSourceControlCommand.cs
+++ b/src/Ankh.Scc/SccUI/Commands/ChangeSourceControlCommand.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio;
 
 using Ankh.UI;
 using Ankh.Commands;
+using Ankh.Services;
 
 namespace Ankh.Scc.SccUI.Commands
 {

--- a/src/Ankh.Scc/SvnSccProvider.Enlistment.cs
+++ b/src/Ankh.Scc/SvnSccProvider.Enlistment.cs
@@ -24,6 +24,7 @@ using SharpSvn;
 using Ankh.Scc.ProjectMap;
 using Ankh.Scc.SettingMap;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/SvnSccProvider.Projects.cs
+++ b/src/Ankh.Scc/SvnSccProvider.Projects.cs
@@ -24,6 +24,7 @@ using Ankh.Selection;
 using System.IO;
 using SharpSvn;
 using Marshal=System.Runtime.InteropServices.Marshal;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/SvnSccProvider.QueryEditSave.cs
+++ b/src/Ankh.Scc/SvnSccProvider.QueryEditSave.cs
@@ -26,6 +26,7 @@ using SharpSvn;
 using Ankh.Commands;
 using Ankh.Scc.ProjectMap;
 using Ankh.Scc.SccUI;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/SvnSccProvider.Solution.cs
+++ b/src/Ankh.Scc/SvnSccProvider.Solution.cs
@@ -18,6 +18,7 @@ using System.Text;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using Ankh.Commands;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Scc/TextEditingTracker.cs
+++ b/src/Ankh.Scc/TextEditingTracker.cs
@@ -18,6 +18,7 @@ using System.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio;
+using Ankh.Services;
 
 namespace Ankh.Scc
 {

--- a/src/Ankh.Services/AnkhContext.cs
+++ b/src/Ankh.Services/AnkhContext.cs
@@ -22,7 +22,7 @@ using System.Windows.Forms.Design;
 using Ankh.Commands;
 using Ankh.Selection;
 
-namespace Ankh
+namespace Ankh.Services
 {
     /// <summary>
     /// Globally available context; the entry point for the service framework.
@@ -64,9 +64,7 @@ namespace Ankh
             if (context == null)
                 throw new ArgumentNullException("context");
 
-            IAnkhServiceProvider sp = context as IAnkhServiceProvider;
-
-            if (sp != null)
+            if (context is IAnkhServiceProvider sp)
                 return new AnkhContext(sp);
             else
                 return new AnkhContext(new AnkhServiceProviderWrapper(context));

--- a/src/Ankh.Services/AnkhModule.cs
+++ b/src/Ankh.Services/AnkhModule.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.ComponentModel.Design;
 using System.Diagnostics;
+using Ankh.Services;
 
 namespace Ankh
 {

--- a/src/Ankh.Services/AnkhRuntime.cs
+++ b/src/Ankh.Services/AnkhRuntime.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using Ankh.UI;
 using System.Threading;
 using System.Runtime.InteropServices;
+using Ankh.Services;
 
 namespace Ankh
 {

--- a/src/Ankh.Services/AnkhService.cs
+++ b/src/Ankh.Services/AnkhService.cs
@@ -25,6 +25,7 @@ using IOleConnectionPoint = Microsoft.VisualStudio.OLE.Interop.IConnectionPoint;
 using IOleConnectionPointContainer = Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer;
 
 using Ankh.VS;
+using Ankh.Services;
 
 namespace Ankh
 {

--- a/src/Ankh.Services/Commands/BaseCommandEventArgs.cs
+++ b/src/Ankh.Services/Commands/BaseCommandEventArgs.cs
@@ -18,6 +18,7 @@ using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell.Interop;
 
 using Ankh.Selection;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh.Services/Commands/CommandEventArgs.cs
+++ b/src/Ankh.Services/Commands/CommandEventArgs.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Ankh.Selection;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh.Services/Commands/CommandMapper.cs
+++ b/src/Ankh.Services/Commands/CommandMapper.cs
@@ -21,6 +21,7 @@ using System.ComponentModel;
 using Microsoft.VisualStudio.OLE.Interop;
 using System.Runtime.InteropServices;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh.Services/Commands/CommandUpdateEventArgs.cs
+++ b/src/Ankh.Services/Commands/CommandUpdateEventArgs.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Ankh.Services;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.Services/IAnkhServiceImplementation.cs
+++ b/src/Ankh.Services/IAnkhServiceImplementation.cs
@@ -16,7 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Ankh
+namespace Ankh.Services
 {
     public interface IAnkhServiceImplementation
     {

--- a/src/Ankh.Services/Scc/ProjectMap/SccDocumentData.cs
+++ b/src/Ankh.Services/Scc/ProjectMap/SccDocumentData.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 using SharpSvn;
 using Ankh.Selection;
+using Ankh.Services;
 
 namespace Ankh.Scc.ProjectMap
 {

--- a/src/Ankh.Services/Scc/ProjectMap/SccProjectData.Hierarchy.cs
+++ b/src/Ankh.Services/Scc/ProjectMap/SccProjectData.Hierarchy.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
+using Ankh.Services;
 
 namespace Ankh.Scc.ProjectMap
 {

--- a/src/Ankh.Services/Scc/ProjectMap/SccProjectData.ProjectRefresh.cs
+++ b/src/Ankh.Services/Scc/ProjectMap/SccProjectData.ProjectRefresh.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.Services/Scc/ProjectMap/SccProjectData.cs
+++ b/src/Ankh.Services/Scc/ProjectMap/SccProjectData.cs
@@ -23,6 +23,7 @@ using SharpSvn;
 using Ankh.Configuration;
 using Ankh.Selection;
 using Ankh.VS;
+using Ankh.Services;
 
 
 namespace Ankh.Scc.ProjectMap

--- a/src/Ankh.Services/Scc/ProjectMap/SccProjectFileReference.cs
+++ b/src/Ankh.Services/Scc/ProjectMap/SccProjectFileReference.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio;
 using SharpSvn;
 using System.Diagnostics;
+using Ankh.Services;
 
 namespace Ankh.Scc.ProjectMap
 {

--- a/src/Ankh.Services/Scc/SccProjectMap.SolutionInfo.cs
+++ b/src/Ankh.Services/Scc/SccProjectMap.SolutionInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 using SharpSvn;
 

--- a/src/Ankh.Services/Scc/SccProvider.Glyphs.cs
+++ b/src/Ankh.Services/Scc/SccProvider.Glyphs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.Scc

--- a/src/Ankh.Services/Scc/SccProvider.Service.cs
+++ b/src/Ankh.Services/Scc/SccProvider.Service.cs
@@ -6,6 +6,7 @@ using IObjectWithSite = Microsoft.VisualStudio.OLE.Interop.IObjectWithSite;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using IOleConnectionPoint = Microsoft.VisualStudio.OLE.Interop.IConnectionPoint;
 using IOleConnectionPointContainer = Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer;
+using Ankh.Services;
 
 
 namespace Ankh.Scc

--- a/src/Ankh.Services/Scc/SccProvider.cs
+++ b/src/Ankh.Services/Scc/SccProvider.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Ankh.Configuration;
 using Ankh.Scc.ProjectMap;
 using Ankh.Selection;
+using Ankh.Services;
 using Ankh.VS;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.Services/Selection/SccHierarchy.cs
+++ b/src/Ankh.Services/Selection/SccHierarchy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.Selection

--- a/src/Ankh.Services/Selection/SelectionItemMap.cs
+++ b/src/Ankh.Services/Selection/SelectionItemMap.cs
@@ -19,6 +19,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Ankh.Services;
 
 namespace Ankh.Selection
 {

--- a/src/Ankh.Services/VSErr.cs
+++ b/src/Ankh.Services/VSErr.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Ankh
+namespace Ankh.Services
 {
     public static class VSErr
     {

--- a/src/Ankh.Services/VSVersion.cs
+++ b/src/Ankh.Services/VSVersion.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.VisualStudio.Shell.Interop;
 using System.Text.RegularExpressions;
+using Ankh.Services;
 
 namespace Ankh
 {

--- a/src/Ankh.Services/XCast.cs
+++ b/src/Ankh.Services/XCast.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Ankh
+namespace Ankh.Services
 {
     [CLSCompliant(false)]
-    public struct XCastUInt32
+    public readonly struct XCastUInt32
     {
         public readonly IntPtr Value;
 
@@ -43,7 +43,7 @@ namespace Ankh
         }
     }
 
-    public struct XCastInt32
+    public readonly struct XCastInt32
     {
         public readonly IntPtr Value;
 

--- a/src/Ankh.UI/OptionsPages/AddAdvancedDiffUserTool.cs
+++ b/src/Ankh.UI/OptionsPages/AddAdvancedDiffUserTool.cs
@@ -11,7 +11,7 @@ namespace Ankh.UI.OptionsPages
 {
     public partial class AddAdvancedDiffUserTool : VSDialogForm
     {
-        private ListView myListView;
+        private readonly ListView myListView;
         private ListViewItem myItem;
 
         public AddAdvancedDiffUserTool(ListView listview, IAnkhDiffHandler diff)
@@ -21,12 +21,12 @@ namespace Ankh.UI.OptionsPages
             LoadBox(diffExeBox, "", diff.DiffToolTemplates);
         }
 
-        private void cancelButton_Click(object sender, EventArgs e)
+        private void CancelButton_Click(object sender, EventArgs e)
         {
             this.Close();
         }
 
-        private void okButton_Click(object sender, EventArgs e)
+        private void OkButton_Click(object sender, EventArgs e)
         {
             if (myItem == null)
             {
@@ -43,26 +43,16 @@ namespace Ankh.UI.OptionsPages
             this.Close();
         }    
 
-        public void setItem(ListViewItem myInputItem)
+        public void SetItem(ListViewItem myInputItem)
         {
             myItem = myInputItem;
             extensionTextBox.Text = myItem.Text;
             diffExeBox.Text = myItem.SubItems[1].Text;
         }
 
-
-
-
-        //protected override void LoadSettingsCore()
-        //{
-        //    IAnkhDiffHandler diff = Context.GetService<IAnkhDiffHandler>();
-
-        //    LoadBox(diffExeBox, Config.DiffExePath, diff.DiffToolTemplates);
-        //}
-
         sealed class OtherTool
         {
-            string _title;
+            readonly string _title;
             public OtherTool(string title)
             {
                 _title = string.IsNullOrEmpty(title) ? "Other..." : title;
@@ -117,31 +107,10 @@ namespace Ankh.UI.OptionsPages
             }
         }
 
-
-        //protected override void SaveSettingsCore()
-        //{
-        //    Config.DiffExePath = SaveBox(diffExeBox);
-        //}
-
-        static string SaveBox(ComboBox box)
-        {
-            if (box == null)
-                throw new ArgumentNullException("box");
-
-            AnkhDiffTool tool = box.SelectedItem as AnkhDiffTool;
-
-            if (tool != null)
-                return tool.ToolTemplate;
-
-            return box.Text;
-        }
-
         void BrowseCombo(ComboBox box)
         {
-            AnkhDiffTool tool = box.SelectedItem as AnkhDiffTool;
-
             string line;
-            if (tool != null)
+            if (box.SelectedItem is AnkhDiffTool tool)
             {
                 line = string.Format("\"{0}\" {1}", tool.Program, tool.Arguments);
             }
@@ -167,7 +136,7 @@ namespace Ankh.UI.OptionsPages
             }
         }
 
-        private void diffExeBox_TextChanged(object sender, EventArgs e)
+        private void DiffExeBox_TextChanged(object sender, EventArgs e)
         {
             ComboBox box = (ComboBox)sender;
 
@@ -180,16 +149,13 @@ namespace Ankh.UI.OptionsPages
             }
         }
 
-        private void tool_selectionCommitted(object sender, EventArgs e)
+        private void Tool_selectionCommitted(object sender, EventArgs e)
         {
             ComboBox box = (ComboBox)sender;
 
-            AnkhDiffTool tool = box.SelectedItem as AnkhDiffTool;
-
-            if (tool != null)
+            if (box.SelectedItem is AnkhDiffTool tool)
             {
                 box.DropDownStyle = ComboBoxStyle.DropDownList;
-                //box.Tag = tool.ToolTemplate;
                 box.Tag = string.Format("\"{0}\" {1}", tool.Program, tool.Arguments);
                 box.Text = (string)box.Tag;
 
@@ -199,10 +165,10 @@ namespace Ankh.UI.OptionsPages
                 box.DropDownStyle = ComboBoxStyle.DropDown;
                 if (box.SelectedItem != null)
                     box.SelectedItem = null;
-                if (box.Tag is string)
-                    box.Text = (string)box.Tag;
-                else if (box.Tag is AnkhDiffTool)
-                    box.Text = ((AnkhDiffTool)box.Tag).ToolTemplate;
+                if (box.Tag is string text)
+                    box.Text = text;
+                else if (box.Tag is AnkhDiffTool tool1)
+                    box.Text = tool1.ToolTemplate;
 
                 if (!string.IsNullOrEmpty(box.Text))
                 {
@@ -212,7 +178,7 @@ namespace Ankh.UI.OptionsPages
             }
         }
 
-        private void diffBrowseBtn_Click(object sender, EventArgs e)
+        private void DiffBrowseBtn_Click(object sender, EventArgs e)
         {
             BrowseCombo(diffExeBox);
         }

--- a/src/Ankh.UI/OptionsPages/AddAdvancedDiffUserTool.designer.cs
+++ b/src/Ankh.UI/OptionsPages/AddAdvancedDiffUserTool.designer.cs
@@ -71,7 +71,7 @@
             this.okButton.TabIndex = 21;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            this.okButton.Click += new System.EventHandler(this.OkButton_Click);
             // 
             // cancelButton
             // 
@@ -84,14 +84,14 @@
             this.cancelButton.TabIndex = 22;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
             // diffExeBox
             // 
             this.diffExeBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.diffExeBox.SelectionChangeCommitted += new System.EventHandler(this.tool_selectionCommitted);
-            this.diffExeBox.TextChanged += new System.EventHandler(this.diffExeBox_TextChanged);
+            this.diffExeBox.SelectionChangeCommitted += new System.EventHandler(this.Tool_selectionCommitted);
+            this.diffExeBox.TextChanged += new System.EventHandler(this.DiffExeBox_TextChanged);
             this.diffExeBox.DisplayMember = "DisplayName";
             this.diffExeBox.Location = new System.Drawing.Point(73, 41);
             this.diffExeBox.Name = "diffExeBox";

--- a/src/Ankh.UI/OptionsPages/AdvancedDiffUserToolSettingsControl.cs
+++ b/src/Ankh.UI/OptionsPages/AdvancedDiffUserToolSettingsControl.cs
@@ -71,7 +71,7 @@ namespace Ankh.UI.OptionsPages
 
             using (AddAdvancedDiffUserTool myAddAdvancedUserTool = new AddAdvancedDiffUserTool(listView, diffHandler))
             {
-                myAddAdvancedUserTool.setItem(listView.SelectedItems[0]);
+                myAddAdvancedUserTool.SetItem(listView.SelectedItems[0]);
                 myAddAdvancedUserTool.ShowDialog(Context);
             }
         }

--- a/src/Ankh.UI/PendingChanges/Commands/OpenIssue.cs
+++ b/src/Ankh.UI/PendingChanges/Commands/OpenIssue.cs
@@ -9,6 +9,7 @@ using Ankh.Selection;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio;
 using System.Runtime.InteropServices;
+using Ankh.Services;
 
 
 namespace Ankh.UI.PendingChanges.Commands

--- a/src/Ankh.UI/WorkingCopyExplorer/FileSystemListViewItem.cs
+++ b/src/Ankh.UI/WorkingCopyExplorer/FileSystemListViewItem.cs
@@ -31,10 +31,7 @@ namespace Ankh.UI.WorkingCopyExplorer
         public FileSystemListViewItem(SmartListView view, SvnItem item)
             : base(view)
         {
-            if (item == null)
-                throw new ArgumentNullException("item");
-            
-            _svnItem = item;
+            _svnItem = item ?? throw new ArgumentNullException("item");
 
             ImageIndex = View.IconMapper.GetIcon(item.FullPath);
 
@@ -56,7 +53,7 @@ namespace Ankh.UI.WorkingCopyExplorer
     
         private void RefreshValues()
         {
-            bool exists = SvnItem.Exists;
+            _ = SvnItem.Exists;
             string name = string.IsNullOrEmpty(SvnItem.Name) ? SvnItem.FullPath : SvnItem.Name;
 
             SvnStatusData status = SvnItem.Status;

--- a/src/Ankh.VS.UnitTest/CommandRouting/CommandRoutingTest.cs
+++ b/src/Ankh.VS.UnitTest/CommandRouting/CommandRoutingTest.cs
@@ -34,6 +34,7 @@ using System.Windows.Forms.Design;
 using System.Windows.Forms;
 using System.IO;
 using Microsoft.VsSDK.UnitTestLibrary;
+using Ankh.Services;
 
 namespace AnkhSvn_UnitTestProject.CommandRouting
 {

--- a/src/Ankh.VS.UnitTest/CommandRouting/CommandTests.cs
+++ b/src/Ankh.VS.UnitTest/CommandRouting/CommandTests.cs
@@ -26,6 +26,7 @@ using Ankh.Selection;
 using Ankh.UI;
 using Ankh.VS;
 using AnkhSvn_UnitTestProject.Helpers;
+using Ankh.Services;
 
 namespace AnkhSvn_UnitTestProject.CommandRouting
 {

--- a/src/Ankh.VS.UnitTest/Helpers/CommandExecutor.cs
+++ b/src/Ankh.VS.UnitTest/Helpers/CommandExecutor.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 using Ankh;
+using Ankh.Services;
 
 namespace AnkhSvn_UnitTestProject.Helpers
 {

--- a/src/Ankh.VS.UnitTest/MenuItemTests/MenuItemCallback.cs
+++ b/src/Ankh.VS.UnitTest/MenuItemTests/MenuItemCallback.cs
@@ -41,6 +41,7 @@ using Ankh.UI;
 using System.Windows.Forms.Design;
 using System.Windows.Forms;
 using Microsoft.VisualStudio;
+using Ankh.Services;
 
 namespace UnitTestProject.MenuItemTests
 {

--- a/src/Ankh.VS.UnitTest/PackageTest.cs
+++ b/src/Ankh.VS.UnitTest/PackageTest.cs
@@ -32,13 +32,13 @@ using Ankh.VSPackage;
 using EnvDTE;
 using AnkhSvn_UnitTestProject.Mocks;
 using AnkhSvn_UnitTestProject.Helpers;
-using Ankh;
 using Ankh.Scc;
 using NUnit.Framework;
 using Moq;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.OLE.Interop;
+using Ankh.Services;
 
 namespace UnitTestProject
 {

--- a/src/Ankh.VS/Dialogs/AnkhDialogOwner.cs
+++ b/src/Ankh.VS/Dialogs/AnkhDialogOwner.cs
@@ -67,8 +67,7 @@ namespace Ankh.VS.Dialogs
         {
             VSCommandRouting routing = VSCommandRouting.FromForm(form);
 
-            if (routing != null)
-                routing.OnHandleCreated();
+            routing?.OnHandleCreated();
         }
 
         public AnkhMessageBox MessageBox

--- a/src/Ankh.VS/Dialogs/VSCommandInstaller.cs
+++ b/src/Ankh.VS/Dialogs/VSCommandInstaller.cs
@@ -25,6 +25,7 @@ using Ankh.Scc.UI;
 using Ankh.UI;
 
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
+using Ankh.Services;
 
 namespace Ankh.VS.Dialogs
 {
@@ -73,9 +74,7 @@ namespace Ankh.VS.Dialogs
                 }
             }
 
-            IAnkhVSContainerForm ct = topParent as IAnkhVSContainerForm;
-
-            if (ct != null)
+            if (topParent is IAnkhVSContainerForm ct)
             {
                 ContextCommandHandler cx = new ContextCommandHandler(this, topParent);
                 acc.CommandHook = cx;
@@ -84,8 +83,7 @@ namespace Ankh.VS.Dialogs
                 return;
             }
 
-            IAnkhToolWindowControl toolWindow = topParent as IAnkhToolWindowControl;
-            if (toolWindow != null && toolWindow.ToolWindowHost != null)
+            if (topParent is IAnkhToolWindowControl toolWindow && toolWindow.ToolWindowHost != null)
             {
                 ContextCommandHandler cx = new ContextCommandHandler(this, topParent);
                 acc.CommandHook = cx;
@@ -113,7 +111,7 @@ namespace Ankh.VS.Dialogs
             }
         }
 
-        Dictionary<CommandID, List<CommandData>> _data = new Dictionary<CommandID, List<CommandData>>();
+        readonly Dictionary<CommandID, List<CommandData>> _data = new Dictionary<CommandID, List<CommandData>>();
         public ContextCommandHandler(IAnkhServiceProvider context, Control control)
             : base(context, control)
         {
@@ -123,8 +121,7 @@ namespace Ankh.VS.Dialogs
         {
             CommandData cd = new CommandData(control, handler, updateHandler);
 
-            List<CommandData> items;
-            if (!_data.TryGetValue(command, out items))
+            if (!_data.TryGetValue(command, out List<CommandData> items))
                 _data[command] = items = new List<CommandData>();
 
             items.Add(cd);
@@ -136,9 +133,7 @@ namespace Ankh.VS.Dialogs
         {
             CommandID cd = new CommandID(pguidCmdGroup, unchecked((int)nCmdID));
 
-            List<CommandData> items;
-
-            if (!_data.TryGetValue(cd, out items))
+            if (!_data.TryGetValue(cd, out List<CommandData> items))
                 return VSErr.OLECMDERR_E_NOTSUPPORTED;
 
             foreach (CommandData d in items)
@@ -174,9 +169,7 @@ namespace Ankh.VS.Dialogs
 
             CommandID cd = new CommandID(pguidCmdGroup, unchecked((int)prgCmds[0].cmdID));
 
-            List<CommandData> items;
-
-            if (!_data.TryGetValue(cd, out items))
+            if (!_data.TryGetValue(cd, out List<CommandData> items))
                 return VSErr.OLECMDERR_E_NOTSUPPORTED;
 
             foreach (CommandData d in items)
@@ -186,8 +179,7 @@ namespace Ankh.VS.Dialogs
 
                 CommandUpdateEventArgs ee = new CommandUpdateEventArgs((AnkhCommand)cd.ID, GetService<AnkhContext>());
 
-                if (d.UpdateHandler != null)
-                    d.UpdateHandler(d.Control, ee);
+                d.UpdateHandler?.Invoke(d.Control, ee);
 
                 if (ee.DynamicMenuEnd)
                     return VSErr.OLECMDERR_E_NOTSUPPORTED;

--- a/src/Ankh.VS/Dialogs/VSCommandRouting.cs
+++ b/src/Ankh.VS/Dialogs/VSCommandRouting.cs
@@ -26,6 +26,7 @@ using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 
 using Ankh.Selection;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VS.Dialogs
 {
@@ -38,7 +39,7 @@ namespace Ankh.VS.Dialogs
         IVsToolWindowToolbarHost _tbHost;
         IVsFilterKeys2 _fKeys;
         IVsRegisterPriorityCommandTarget _priorityCommandTarget;
-        uint _csCookie;
+        readonly uint _csCookie;
         Panel _panel;
         List<IOleCommandTarget> _ctList;
         List<IVsWindowPane> _paneList;
@@ -50,10 +51,7 @@ namespace Ankh.VS.Dialogs
         public VSCommandRouting(IAnkhServiceProvider context, VSContainerForm form)
             : base(context)
         {
-            if (form == null)
-                throw new ArgumentNullException("form");
-
-            _form = form;
+            _form = form ?? throw new ArgumentNullException("form");
             _vsForm = form;
 
             if (_routers.Count > 0)
@@ -82,9 +80,8 @@ namespace Ankh.VS.Dialogs
 
         public static VSCommandRouting FromForm(VSContainerForm form)
         {
-            VSCommandRouting vr;
 
-            if (_map.TryGetValue(form, out vr))
+            if (_map.TryGetValue(form, out VSCommandRouting vr))
                 return vr;
 
             return null;
@@ -120,17 +117,11 @@ namespace Ankh.VS.Dialogs
                 if (_panel != null)
                     RestoreLayout();
 
-                if (_pane != null)
-                {
-                    _pane.Dispose(); // Unhook
-                    _pane = null;
-                }
+                _pane?.Dispose(); // Unhook
+                _pane = null;
 
-                if (_panel != null)
-                {
-                    _panel.Dispose();
-                    _panel = null;
-                }
+                _panel?.Dispose();
+                _panel = null;
             }
             finally
             {
@@ -251,10 +242,6 @@ namespace Ankh.VS.Dialogs
 
             if (_fKeys != null && 0 != (mode & (VSContainerMode.TranslateKeys | VSContainerMode.UseTextEditorScope)))
             {
-                Guid cmdGuid;
-                uint cmdCode;
-                int cmdTranslated;
-                int keyComboStarts;
 
                 uint dwFlags = (uint)__VSTRANSACCELEXFLAGS.VSTAEXF_AllowModalState;
 
@@ -265,10 +252,10 @@ namespace Ankh.VS.Dialogs
                     dwFlags,
                     0,
                     null,
-                    out cmdGuid,
-                    out cmdCode,
-                    out cmdTranslated,
-                    out keyComboStarts);
+                    out Guid cmdGuid,
+                    out uint cmdCode,
+                    out int cmdTranslated,
+                    out int keyComboStarts);
 
                 if (hr == VSErr.S_OK)
                 {
@@ -305,9 +292,11 @@ namespace Ankh.VS.Dialogs
             {
                 if (_panel == null)
                 {
-                    _panel = new Panel();
-                    _panel.Location = new Point(0, 0);
-                    _panel.Size = _form.ClientRectangle.Size;
+                    _panel = new Panel
+                    {
+                        Location = new Point(0, 0),
+                        Size = _form.ClientRectangle.Size
+                    };
                     _form.Controls.Add(_panel);
                 }
 
@@ -315,11 +304,10 @@ namespace Ankh.VS.Dialogs
 
                 IVsWindowPane p = _pane;
 
-                IntPtr hwnd;
                 Rectangle r = new Rectangle(_form.Location, _form.Size);
                 _form.Location = new Point(0, 0);
 
-                if (!VSErr.Succeeded(p.CreatePaneWindow(_form.Handle, 0, 0, r.Width, r.Height, out hwnd)))
+                if (!VSErr.Succeeded(p.CreatePaneWindow(_form.Handle, 0, 0, r.Width, r.Height, out IntPtr hwnd)))
                 {
                     _pane.Dispose();
                     _pane = null;

--- a/src/Ankh.VS/Dialogs/VSDocumentFormPane.cs
+++ b/src/Ankh.VS/Dialogs/VSDocumentFormPane.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.Shell;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
 using IOleObjectWithSite = Microsoft.VisualStudio.OLE.Interop.IObjectWithSite;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Ankh.Services;
 
 
 namespace Ankh.VS.Dialogs
@@ -221,11 +222,7 @@ namespace Ankh.VS.Dialogs
                 return null;
             else
             {
-                object o = base.GetService(serviceType);
-
-                if (o == null)
-                    o = _host.ServiceProviderHierarchy.GetService(serviceType);
-
+                object o = base.GetService(serviceType) ?? _host.ServiceProviderHierarchy.GetService(serviceType);
                 return o;
             }
         }

--- a/src/Ankh.VS/Dialogs/VSDocumentHostService.cs
+++ b/src/Ankh.VS/Dialogs/VSDocumentHostService.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Ankh.Services;
 using Ankh.UI;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -41,12 +42,11 @@ namespace Ankh.VS.Dialogs
         public void InitializeEditor(VSEditorControl form, IVsUIHierarchy hier, IVsWindowFrame frame, uint docid)
         {
             VSDocumentFormPane pane = null;
-            object value;
-            if (VSErr.Succeeded(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out value)))
+
+            if (VSErr.Succeeded(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object value)))
             {
                 pane = value as VSDocumentFormPane;
             }
-
 
             if (pane != null)
                 ((IVSEditorControlInit)form).InitializedForm(hier, docid, frame, pane.Host);

--- a/src/Ankh.VS/Dialogs/VSDocumentInstance.cs
+++ b/src/Ankh.VS/Dialogs/VSDocumentInstance.cs
@@ -27,6 +27,7 @@ using ShellPackage = Microsoft.VisualStudio.Shell.Package;
 
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Ankh.Services;
 
 
 namespace Ankh.VS.Dialogs

--- a/src/Ankh.VS/LanguageServices/Core/AnkhCodeWindowManager.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhCodeWindowManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 
@@ -18,10 +18,7 @@ namespace Ankh.VS.LanguageServices.Core
         public AnkhCodeWindowManager(AnkhLanguage language, IVsCodeWindow window)
             : base(language)
         {
-            if (window == null)
-                throw new ArgumentNullException("window");
-
-            _window = window;
+            _window = window ?? throw new ArgumentNullException("window");
             _views = new List<IVsTextView>();
 
             if (!TryHookConnectionPoint<IVsCodeWindowEvents>(_window, this, out _cookie))
@@ -62,11 +59,10 @@ namespace Ankh.VS.LanguageServices.Core
 
         public int AddAdornments()
         {
-            IVsTextView primaryView, secondaryView;
-            if (VSErr.Succeeded(_window.GetPrimaryView(out primaryView)) && primaryView != null)
+            if (VSErr.Succeeded(_window.GetPrimaryView(out IVsTextView primaryView)) && primaryView != null)
                 OnNewView(primaryView);
 
-            if (VSErr.Succeeded(_window.GetSecondaryView(out secondaryView)) && secondaryView != null)
+            if (VSErr.Succeeded(_window.GetSecondaryView(out IVsTextView secondaryView)) && secondaryView != null)
                 OnNewView(secondaryView);
 
             if (primaryView != null || secondaryView != null)
@@ -88,9 +84,8 @@ namespace Ankh.VS.LanguageServices.Core
         {
             AnkhLanguageDropDownBar bar = _bar;
             _bar = null;
+            bar?.Close();
 
-            if (bar != null)
-                bar.Close();
             return VSErr.S_OK;
         }
 
@@ -101,9 +96,7 @@ namespace Ankh.VS.LanguageServices.Core
             {
                 _views.Add(view);
                 Language.OnNewView(this, view);
-
-                if (_bar != null)
-                    _bar.OnNewView(view);
+                _bar?.OnNewView(view);
             }
 
             return VSErr.S_OK;
@@ -117,9 +110,7 @@ namespace Ankh.VS.LanguageServices.Core
             {
                 _views.Remove(view);
 
-                if (_bar != null)
-                    _bar.OnCloseView(view);
-
+                _bar?.OnCloseView(view);
 
                 Language.OnCloseView(this, view);
 

--- a/src/Ankh.VS/LanguageServices/Core/AnkhColorizer.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhColorizer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
-
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 
@@ -17,10 +17,7 @@ namespace Ankh.VS.LanguageServices.Core
         public AnkhColorizer(AnkhLanguage language, IVsTextLines lines)
             : base(language)
         {
-            if (lines == null)
-                throw new ArgumentNullException("lines");
-
-            _lines = lines;
+            _lines = lines ?? throw new ArgumentNullException("lines");
         }
 
         protected AnkhLanguage Language
@@ -53,8 +50,7 @@ namespace Ankh.VS.LanguageServices.Core
         {
             string text = Marshal.PtrToStringUni(pszText, iLength);
 
-            int endState;
-            ColorizeLine(text, iLine, iState, pAttributes, out endState);
+            ColorizeLine(text, iLine, iState, pAttributes, out int endState);
             return endState; // End state
         }
 
@@ -75,9 +71,7 @@ namespace Ankh.VS.LanguageServices.Core
                 throw new ArgumentOutOfRangeException("lineNr");
             else if (_lines == null)
                 return null;
-
-            int lastLine, lastIndex;
-            if (!VSErr.Succeeded(_lines.GetLastLineIndex(out lastLine, out lastIndex)))
+            if (!VSErr.Succeeded(_lines.GetLastLineIndex(out int lastLine, out _)))
                 return null;
 
             if (lineNr > lastLine)
@@ -106,9 +100,7 @@ namespace Ankh.VS.LanguageServices.Core
         {
             string text = Marshal.PtrToStringUni(pszText, iLength);
 
-            int endState;
-
-            GetStateAtEndOfLine(text, iLine, iState, out endState);
+            GetStateAtEndOfLine(text, iLine, iState, out int endState);
 
             return endState;
         }

--- a/src/Ankh.VS/LanguageServices/Core/AnkhEditorFactory.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhEditorFactory.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿using Ankh.Configuration;
+using Ankh.Services;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.Win32;
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
-using Microsoft.Win32;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using IServiceProvider = System.IServiceProvider;
-using Ankh.Configuration;
 
 namespace Ankh.VS.LanguageServices.Core
 {
@@ -328,15 +330,14 @@ namespace Ankh.VS.LanguageServices.Core
                 }
             }
 
-            IVsTextLines buffer = null;
+            IVsTextLines buffer;
             if (existingDocData != IntPtr.Zero)
             {
                 object dataObject = Marshal.GetObjectForIUnknown(existingDocData);
                 buffer = dataObject as IVsTextLines;
                 if (buffer == null)
                 {
-                    IVsTextBufferProvider bp = dataObject as IVsTextBufferProvider;
-                    if (bp != null)
+                    if (dataObject is IVsTextBufferProvider bp)
                     {
                         Marshal.ThrowExceptionForHR(bp.GetTextBuffer(out buffer));
                     }
@@ -358,8 +359,7 @@ namespace Ankh.VS.LanguageServices.Core
                 buffer = (IVsTextLines)package.CreateInstance(ref clsid, ref riid, textLinesType);
                 if (!string.IsNullOrEmpty(moniker))
                 {
-                    IVsUserData iud = buffer as IVsUserData;
-                    if (iud != null)
+                    if (buffer is IVsUserData iud)
                     {
                         Guid GUID_VsBufferMoniker = typeof(IVsUserData).GUID;
                         // Must be set in time for language service GetColorizer call in case the colorizer
@@ -367,16 +367,15 @@ namespace Ankh.VS.LanguageServices.Core
                         Marshal.ThrowExceptionForHR(iud.SetData(ref GUID_VsBufferMoniker, moniker));
                     }
                 }
-                IObjectWithSite ows = buffer as IObjectWithSite;
-                if (ows != null)
+                if (buffer is IObjectWithSite ows)
                 {
                     ows.SetSite(this.site.GetService(typeof(IOleServiceProvider)));
                 }
             }
 
-            if (this.promptFlags == __PROMPTONLOADFLAGS.codepagePrompt && buffer is IVsUserData)
+            if (this.promptFlags == __PROMPTONLOADFLAGS.codepagePrompt && buffer is IVsUserData data)
             {
-                IVsUserData iud = (IVsUserData)buffer;
+                IVsUserData iud = data;
                 Guid GUID_VsBufferEncodingPromptOnLoad = new Guid(0x99ec03f0, 0xc843, 0x4c09, 0xbe, 0x74, 0xcd, 0xca, 0x51, 0x58, 0xd3, 0x6c);
                 Marshal.ThrowExceptionForHR(iud.SetData(ref GUID_VsBufferEncodingPromptOnLoad, (uint)this.CodePagePrompt));
             }
@@ -385,8 +384,7 @@ namespace Ankh.VS.LanguageServices.Core
             if (langSid != Guid.Empty)
             {
                 Guid vsCoreSid = new Guid("{8239bec4-ee87-11d0-8c98-00c04fc2ab22}");
-                Guid currentSid;
-                Marshal.ThrowExceptionForHR(buffer.GetLanguageServiceID(out currentSid));
+                Marshal.ThrowExceptionForHR(buffer.GetLanguageServiceID(out Guid currentSid));
                 // If the language service is set to the default SID, then
                 // set it to our language
                 if (currentSid == vsCoreSid)
@@ -448,7 +446,6 @@ namespace Ankh.VS.LanguageServices.Core
             Guid riid = tcw.GUID;
             // Once this is done the project's assembly reference to "$(EnvRefPath)\Microsoft.VisualStudio.Editor.dll" may be removed
             Guid clsid = typeof(VsCodeWindowClass).GUID;
-            IntPtr docView = IntPtr.Zero;
             IVsCodeWindow window = (IVsCodeWindow)package.CreateInstance(ref clsid, ref riid, tcw);
 
             Marshal.ThrowExceptionForHR(window.SetBuffer(buffer));
@@ -457,7 +454,7 @@ namespace Ankh.VS.LanguageServices.Core
 
             Guid CMDUIGUID_TextEditor = new Guid(0x8B382828, 0x6202, 0x11d1, 0x88, 0x70, 0x00, 0x00, 0xF8, 0x75, 0x79, 0xD2);
             cmdUI = CMDUIGUID_TextEditor;
-            docView = Marshal.GetIUnknownForObject(window);
+            IntPtr docView = Marshal.GetIUnknownForObject(window);
 
             return docView;
         }
@@ -517,10 +514,9 @@ namespace Ankh.VS.LanguageServices.Core
             if (AnkhEditorFactory.languageExtensions != null)
                 return AnkhEditorFactory.languageExtensions;
 
-            IAnkhConfigurationService configService = site.GetService(typeof(IAnkhConfigurationService)) as IAnkhConfigurationService;
             StringDictionary extensions = new StringDictionary();
 
-            if (configService != null)
+            if (site.GetService(typeof(IAnkhConfigurationService)) is IAnkhConfigurationService configService)
                 using (RegistryKey key = configService.OpenVSInstanceKey("Languages\\File Extensions"))
                 {
                     if (key != null)
@@ -552,8 +548,8 @@ namespace Ankh.VS.LanguageServices.Core
                 return AnkhEditorFactory.editors;
 
             Hashtable editors = new Hashtable();
-            IAnkhConfigurationService configService = site.GetService(typeof(IAnkhConfigurationService)) as IAnkhConfigurationService;
-            if (configService == null)
+
+            if (!(site.GetService(typeof(IAnkhConfigurationService)) is IAnkhConfigurationService configService))
                 return editors;
 
             using (RegistryKey editorsKey = configService.OpenVSInstanceKey("Editors"))
@@ -573,13 +569,15 @@ namespace Ankh.VS.LanguageServices.Core
                                 {
                                     if (!string.IsNullOrEmpty(s))
                                     {
-                                        EditorInfo ei = new EditorInfo();
-                                        ei.Name = name;
-                                        ei.Guid = guid;
-                                        object obj = extensions.GetValue(s);
-                                        if (obj is int)
+                                        EditorInfo ei = new EditorInfo
                                         {
-                                            ei.Priority = (int)obj;
+                                            Name = name,
+                                            Guid = guid
+                                        };
+                                        object obj = extensions.GetValue(s);
+                                        if (obj is int priority)
+                                        {
+                                            ei.Priority = priority;
                                         }
                                         string ext = (s == "*") ? s : "." + s;
                                         AddEditorInfo(editors, ext, ei);
@@ -623,10 +621,9 @@ namespace Ankh.VS.LanguageServices.Core
 
         StringDictionary GetFileExtensionMappings()
         {
-            IAnkhConfigurationService configService = site.GetService(typeof(IAnkhConfigurationService)) as IAnkhConfigurationService;
-
             StringDictionary map = new StringDictionary();
-            if (configService == null)
+
+            if (!(site.GetService(typeof(IAnkhConfigurationService)) is IAnkhConfigurationService configService))
                 return map;
 
             using (RegistryKey key = configService.OpenVSInstanceKey("Default Editors"))

--- a/src/Ankh.VS/LanguageServices/Core/AnkhLanguage.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhLanguage.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 using Ankh.Selection;
+using Ankh.Services;
 
 
 namespace Ankh.VS.LanguageServices.Core
@@ -114,16 +115,22 @@ namespace Ankh.VS.LanguageServices.Core
 
             if (filter != null)
             {
-                IOleCommandTarget chained;
-                view.AddCommandFilter(filter, out chained);
-
+                view.AddCommandFilter(filter, out IOleCommandTarget chained);
                 filter.AddChained(chained);
             }
         }
 
         internal void OnCloseView(AnkhCodeWindowManager ankhCodeWindowManager, IVsTextView view)
         {
+            if (ankhCodeWindowManager is null)
+            {
+                throw new ArgumentNullException(nameof(ankhCodeWindowManager));
+            }
 
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
         }
 
         [CLSCompliant(false)]

--- a/src/Ankh.VS/LanguageServices/Core/AnkhLanguageDropDownBar.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhLanguageDropDownBar.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VS.LanguageServices.Core
 {
@@ -21,10 +22,7 @@ namespace Ankh.VS.LanguageServices.Core
         public AnkhLanguageDropDownBar(AnkhLanguage language, AnkhCodeWindowManager manager)
             : base(language)
         {
-            if (manager == null)
-                throw new ArgumentNullException("manager");
-
-            _manager = manager;
+            _manager = manager ?? throw new ArgumentNullException("manager");
         }
 
         protected AnkhCodeWindowManager Manager
@@ -49,9 +47,7 @@ namespace Ankh.VS.LanguageServices.Core
 
         protected internal virtual void Initialize()
         {
-            IVsDropdownBarManager dbm = Manager.CodeWindow as IVsDropdownBarManager;
-
-            if (dbm == null)
+            if (!(Manager.CodeWindow is IVsDropdownBarManager dbm))
                 return;
 
             int combos = NumberOfCombos;
@@ -62,8 +58,7 @@ namespace Ankh.VS.LanguageServices.Core
             if (!VSErr.Succeeded(dbm.AddDropdownBar(combos, this)))
                 return;
 
-            IVsDropdownBar bar;
-            if (!VSErr.Succeeded(dbm.GetDropdownBar(out bar)))
+            if (!VSErr.Succeeded(dbm.GetDropdownBar(out IVsDropdownBar bar)))
                 return;
 
             _added = true;
@@ -164,8 +159,7 @@ namespace Ankh.VS.LanguageServices.Core
 
                 if (_activeView != null)
                 {
-                    int line, col;
-                    if (VSErr.Succeeded(_activeView.GetCaretPos(out line, out col)))
+                    if (VSErr.Succeeded(_activeView.GetCaretPos(out int line, out int col)))
                     {
                         SynchronizeCombos(_activeView, line, col);
                     }
@@ -195,10 +189,7 @@ namespace Ankh.VS.LanguageServices.Core
         [CLSCompliant(false)]
         public int GetComboAttributes(int iCombo, out uint pcEntries, out uint puEntryType, out IntPtr phImageList)
         {
-            int numberOfEntries;
-            DROPDOWNENTRYTYPE entryType;
-            ImageList imageList;
-            GetSettings(iCombo, out numberOfEntries, out entryType, out imageList);
+            GetSettings(iCombo, out int numberOfEntries, out DROPDOWNENTRYTYPE entryType, out ImageList imageList);
             pcEntries = (uint)numberOfEntries;
             puEntryType = (uint)entryType;
 
@@ -315,8 +306,7 @@ namespace Ankh.VS.LanguageServices.Core
 
         internal void OnCloseView(IVsTextView view)
         {
-            ComboTextView v;
-            if (_comboViews.TryGetValue(view, out v))
+            if (_comboViews.TryGetValue(view, out ComboTextView v))
             {
                 _comboViews.Remove(view);
                 v.Dispose();
@@ -331,7 +321,7 @@ namespace Ankh.VS.LanguageServices.Core
         class ComboTextView : AnkhService, IVsTextViewEvents, IDisposable
         {
             IVsTextView _view;
-            uint _cookie;
+            readonly uint _cookie;
 
             public ComboTextView(AnkhLanguageDropDownBar bar, IVsTextView view)
                 : base(bar)
@@ -383,10 +373,10 @@ namespace Ankh.VS.LanguageServices.Core
 
         public class ComboMember
         {
-            string _text;
-            int _image;
+            readonly string _text;
+            readonly int _image;
             TextSpan _span;
-            DROPDOWNFONTATTR _attr;
+            readonly DROPDOWNFONTATTR _attr;
 
             [CLSCompliant(false)]
             public ComboMember(string text, int image, DROPDOWNFONTATTR attr)
@@ -453,7 +443,7 @@ namespace Ankh.VS.LanguageServices.Core
 
         public class ComboMemberCollection : Collection<ComboMember>
         {
-            AnkhLanguageDropDownBar _bar;
+            readonly AnkhLanguageDropDownBar _bar;
             readonly int _index;
             internal int _current;
             bool _dirty;

--- a/src/Ankh.VS/LanguageServices/Core/AnkhLanguagePreferences.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhLanguagePreferences.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Win32;
 using Ankh.Configuration;
+using Ankh.Services;
 
 namespace Ankh.VS.LanguageServices.Core
 {
@@ -35,7 +36,7 @@ namespace Ankh.VS.LanguageServices.Core
     [ComVisible(true), Guid(AnkhId.LanguagePreferencesId), ClassInterface(ClassInterfaceType.AutoDual), ComDefaultInterface(typeof(IAnkhLanguagePreferences))]
     public class AnkhLanguagePreferences : AnkhService, IAnkhLanguagePreferences, IVsTextManagerEvents2
     {
-        Guid langSvc;
+        readonly Guid langSvc;
         LANGPREFERENCES2 prefs;
         uint? _connection;
         bool enableCodeSense;
@@ -204,9 +205,8 @@ namespace Ankh.VS.LanguageServices.Core
         public int GetIntegerValue(RegistryKey key, string name, int def)
         {
             object o = key.GetValue(name);
-            if (o is int) return (int)o;
-            int result;
-            if (o is string && int.TryParse((string)o, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
+            if (o is int v1) return v1;
+            if (o is string v && int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result))
                 return result;
             return def;
         }
@@ -214,9 +214,8 @@ namespace Ankh.VS.LanguageServices.Core
         public bool GetBooleanValue(RegistryKey key, string name, bool def)
         {
             object o = key.GetValue(name);
-            if (o is int) return ((int)o != 0);
-            bool result;
-            if (o is string && bool.TryParse((string)o, out result))
+            if (o is int v1) return (v1 != 0);
+            if (o is string v && bool.TryParse(v, out bool result))
                 return result;
             return def;
         }
@@ -421,9 +420,8 @@ namespace Ankh.VS.LanguageServices.Core
         private void Connect()
         {
             IVsTextManager2 textMgr = GetService<IVsTextManager2>(typeof(SVsTextManager));
-            uint cookie;
-            if (textMgr != null
-                && TryHookConnectionPoint<IVsTextManagerEvents2>(textMgr, this, out cookie))
+
+            if (textMgr != null && TryHookConnectionPoint<IVsTextManagerEvents2>(textMgr, this, out uint cookie))
             {
                 _connection = cookie;
             }

--- a/src/Ankh.VS/LanguageServices/Core/AnkhViewFilter.cs
+++ b/src/Ankh.VS/LanguageServices/Core/AnkhViewFilter.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using OleConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
+using Ankh.Services;
 
 
 
@@ -22,6 +23,15 @@ namespace Ankh.VS.LanguageServices.Core
         public AnkhViewFilter(AnkhCodeWindowManager codeWindowManager, IVsTextView textView)
             : base(codeWindowManager)
         {
+            if (codeWindowManager is null)
+            {
+                throw new ArgumentNullException(nameof(codeWindowManager));
+            }
+
+            if (textView is null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
         }
 
         protected AnkhCodeWindowManager CodeWindowManager

--- a/src/Ankh.VS/LanguageServices/LogMessages/LogMessageColorizer.cs
+++ b/src/Ankh.VS/LanguageServices/LogMessages/LogMessageColorizer.cs
@@ -89,8 +89,7 @@ namespace Ankh.VS.LanguageServices.LogMessages
 
             if (IssueService != null)
             {
-                IEnumerable<TextMarker> markers;
-                if (IssueService.TryGetRevisions(combined, out markers))
+                if (IssueService.TryGetRevisions(combined, out IEnumerable<TextMarker> markers))
                     foreach (TextMarker im in markers)
                     {
                         int from = Math.Max(im.Index, start);

--- a/src/Ankh.VS/LanguageServices/UnifiedDiff/UnifiedDiffDropDownBar.cs
+++ b/src/Ankh.VS/LanguageServices/UnifiedDiff/UnifiedDiffDropDownBar.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio;
 
 using Ankh.VS.LanguageServices.Core;
+using Ankh.Services;
 
 namespace Ankh.VS.LanguageServices.UnifiedDiff
 {
@@ -91,8 +92,7 @@ namespace Ankh.VS.LanguageServices.UnifiedDiff
         {
             IVsTextLines lines = _buffer;
 
-            int lastLine, linelen;
-            Marshal.ThrowExceptionForHR(lines.GetLastLineIndex(out lastLine, out linelen));
+            Marshal.ThrowExceptionForHR(lines.GetLastLineIndex(out int lastLine, out int linelen));
 
             bool changed = false;
 
@@ -103,8 +103,7 @@ namespace Ankh.VS.LanguageServices.UnifiedDiff
                 if (linelen < 8)
                     continue; // No 'Index: ' line
 
-                string start;
-                Marshal.ThrowExceptionForHR(lines.GetLineText(i, 0, i, 7, out start));
+                Marshal.ThrowExceptionForHR(lines.GetLineText(i, 0, i, 7, out string start));
                 if (!string.Equals(start, "Index: "))
                     continue;
 
@@ -155,6 +154,11 @@ namespace Ankh.VS.LanguageServices.UnifiedDiff
 
         public int OnLoadCompleted(int fReload)
         {
+            if (fReload < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fReload), fReload, $"'{nameof(fReload)}' cannot be negative");
+            }
+
             _shouldParse = true;
             return VSErr.S_OK;
         }

--- a/src/Ankh.VS/Selection/AnkhCommandService.cs
+++ b/src/Ankh.VS/Selection/AnkhCommandService.cs
@@ -26,8 +26,9 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Ankh.Commands;
 using Ankh.UI;
 using Ankh.VS;
+using Ankh.Services;
 
-namespace Ankh.Services
+namespace Ankh.VS.Selection
 {
     [GlobalService(typeof(IAnkhCommandService))]
     sealed class AnkhCommandService : AnkhService, IAnkhCommandService, IAnkhIdleProcessor

--- a/src/Ankh.VS/Selection/CachedEnumerable.cs
+++ b/src/Ankh.VS/Selection/CachedEnumerable.cs
@@ -139,10 +139,7 @@ namespace Ankh.VS.Selection
 
             public Walker(CachedEnumerable<T> cache)
             {
-                if (cache == null)
-                    throw new ArgumentNullException("cache");
-
-                _cache = cache;
+                _cache = cache ?? throw new ArgumentNullException("cache");
             }
 
             public bool MoveNext()

--- a/src/Ankh.VS/Selection/CommandState.cs
+++ b/src/Ankh.VS/Selection/CommandState.cs
@@ -24,6 +24,7 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using Ankh.Selection;
 using Ankh.Configuration;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VS.Selection
 {
@@ -51,12 +52,11 @@ namespace Ankh.VS.Selection
 
             if (shell != null)
             {
-                object v;
 
-                if (!VSErr.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_Zombie, out v)))
+                if (!VSErr.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_Zombie, out object v)))
                     _zombie = false;
                 else
-                    _zombie = (v is bool) && ((bool)v);
+                    _zombie = (v is bool v1) && v1;
 
                 if (!VSErr.Succeeded(shell.AdviseShellPropertyChanges(this, out _shellPropsCookie)))
                     _shellPropsCookie = 0;
@@ -79,8 +79,7 @@ namespace Ankh.VS.Selection
                     _shellPropsCookie = 0;
 
                     IVsShell shell = GetService<IVsShell>(typeof(SVsShell));
-                    if (shell != null)
-                        shell.UnadviseShellPropertyChanges(ck);
+                    shell?.UnadviseShellPropertyChanges(ck);
                 }
             }
             finally
@@ -96,8 +95,7 @@ namespace Ankh.VS.Selection
 
         void OnCmdUIContextChanged(object sender, CmdUIContextChangeEventArgs e)
         {
-            CmdStateCacheItem item;
-            if (_cookieMap.TryGetValue(e.Cookie, out item))
+            if (_cookieMap.TryGetValue(e.Cookie, out CmdStateCacheItem item))
                 item.Active = e.Active;
 
             ClearState();
@@ -117,14 +115,11 @@ namespace Ankh.VS.Selection
 
         private CmdStateCacheItem GetCache(Guid cmdContextId)
         {
-            uint cookie;
 
-            if (!VSErr.Succeeded(Monitor.GetCmdUIContextCookie(ref cmdContextId, out cookie)))
+            if (!VSErr.Succeeded(Monitor.GetCmdUIContextCookie(ref cmdContextId, out uint cookie)))
                 return new CmdStateCacheItem(Monitor, 0);
 
-            CmdStateCacheItem item;
-
-            if (!_cookieMap.TryGetValue(cookie, out item))
+            if (!_cookieMap.TryGetValue(cookie, out CmdStateCacheItem item))
             {
                 _cookieMap[cookie] = item = new CmdStateCacheItem(Monitor, cookie);
             }
@@ -398,10 +393,9 @@ namespace Ankh.VS.Selection
 
             _themeLight = _themeDark = false;
             IAnkhConfigurationService config = GetService<IAnkhConfigurationService>();
-            Guid themeGuid;
 
             if (config == null
-                || !GetService<IWinFormsThemingService>().GetCurrentTheme(out themeGuid))
+                || !GetService<IWinFormsThemingService>().GetCurrentTheme(out Guid themeGuid))
             {
                 _themed = false;
                 return;
@@ -426,10 +420,10 @@ namespace Ankh.VS.Selection
                 else
                     v = null;
 
-                if (v is int)
+                if (v is int v1)
                 {
                     _themed = true;
-                    int vv = (int)v;
+                    int vv = v1;
 
                     _themeLight = (vv & 0x01) != 0;
                     _themeDark = (vv & 0x02) != 0;
@@ -459,8 +453,7 @@ namespace Ankh.VS.Selection
 
             internal void Reload(IVsMonitorSelection monitor)
             {
-                int active;
-                _active = VSErr.Succeeded(monitor.IsCmdUIContextActive(_cookie, out active)) && active != 0;
+                _active = VSErr.Succeeded(monitor.IsCmdUIContextActive(_cookie, out int active)) && active != 0;
             }
 
             public bool Active
@@ -519,8 +512,7 @@ namespace Ankh.VS.Selection
 
                         IVsSccProvider pv = GetService<IAnkhQueryService>().QueryService<IVsSccProvider>(gService);
 
-                        int iManaging;
-                        if (pv != null && VSErr.Succeeded(pv.AnyItemsUnderSourceControl(out iManaging)))
+                        if (pv != null && VSErr.Succeeded(pv.AnyItemsUnderSourceControl(out int iManaging)))
                         {
                             if (iManaging != 0)
                                 return true;
@@ -541,10 +533,8 @@ namespace Ankh.VS.Selection
                 List<SccData> sccs = new List<SccData>();
 
                 ILocalRegistry2 lr = GetService<ILocalRegistry2>(typeof(SLocalRegistry));
-
-                string root;
-                List<string> names = new List<string>();
-                if (VSErr.Succeeded(lr.GetLocalRegistryRoot(out root)))
+                _ = new List<string>();
+                if (VSErr.Succeeded(lr.GetLocalRegistryRoot(out string root)))
                 {
                     RegistryKey baseKey = Registry.LocalMachine;
 
@@ -606,8 +596,7 @@ namespace Ankh.VS.Selection
                 return false;
 
             // If the active manager is not installed, it is not active
-            int installed = 0;
-            if (!VSErr.Succeeded(manager.IsInstalled(out installed)) || (installed == 0))
+            if (!VSErr.Succeeded(manager.IsInstalled(out int installed)) || (installed == 0))
                 return false;
 
             if (GetOtherSccActive())
@@ -646,8 +635,7 @@ namespace Ankh.VS.Selection
                     if (!_zombie)
                     {
                         IAnkhServiceEvents se = GetService<IAnkhServiceEvents>();
-                        if (se != null)
-                            se.OnUIShellActivate(EventArgs.Empty);
+                        se?.OnUIShellActivate(EventArgs.Empty);
                     }
                     break;
             }

--- a/src/Ankh.VS/Selection/SelectionContext.Active.cs
+++ b/src/Ankh.VS/Selection/SelectionContext.Active.cs
@@ -23,6 +23,7 @@ using Ankh.Selection;
 using SharpSvn;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VS.Selection
 {

--- a/src/Ankh.VS/Selection/SelectionContext.Delay.cs
+++ b/src/Ankh.VS/Selection/SelectionContext.Delay.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Ankh.Commands;
 using Microsoft.VisualStudio;
+using Ankh.Services;
 
 namespace Ankh.VS.Selection
 {

--- a/src/Ankh.VS/Selection/SelectionContext.SelectionItem.cs
+++ b/src/Ankh.VS/Selection/SelectionContext.SelectionItem.cs
@@ -27,10 +27,7 @@ namespace Ankh.VS.Selection
 
         public SelectionItem(IVsHierarchy hierarchy, uint id)
         {
-            if (hierarchy == null)
-                throw new ArgumentNullException("hierarchy");
-
-            _hierarchy = hierarchy;
+            _hierarchy = hierarchy ?? throw new ArgumentNullException("hierarchy");
             _id = id;
         }
 

--- a/src/Ankh.VS/Selection/SelectionContext.cs
+++ b/src/Ankh.VS/Selection/SelectionContext.cs
@@ -27,6 +27,7 @@ using SharpSvn;
 using Ankh.Scc;
 using Ankh.Selection;
 using Ankh.VS.SolutionExplorer;
+using Ankh.Services;
 
 
 namespace Ankh.VS.Selection

--- a/src/Ankh.VS/Selection/SelectionUtils.cs
+++ b/src/Ankh.VS/Selection/SelectionUtils.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using IServiceProvider = System.IServiceProvider;
 using System.Runtime.InteropServices;
 using Microsoft;
+using Ankh.Services;
 
 namespace Ankh.VS.Selection
 {
@@ -90,7 +91,6 @@ namespace Ankh.VS.Selection
 
             try
             {
-
                 if (sccProject != null)
                 {
                     CALPOLESTR[] str = new CALPOLESTR[1];
@@ -113,14 +113,12 @@ namespace Ankh.VS.Selection
                 // If sccProject2.GetSccFiles() returns E_NOTIMPL we must try GetMkDocument
                 // We also try this if the item does not implement IVsSccProject2
 
-                IVsProject project = hierarchy as IVsProject;
-                if (project != null)
+                if (hierarchy is IVsProject project)
                 {
-                    string mkDocument;
 
                     try
                     {
-                        if (VSErr.Succeeded(project.GetMkDocument(id, out mkDocument)))
+                        if (VSErr.Succeeded(project.GetMkDocument(id, out string mkDocument)))
                         {
                             if (!IsValidPath(mkDocument, true))
                                 files = new string[0];
@@ -141,10 +139,9 @@ namespace Ankh.VS.Selection
                     return ok; // Will fail in GetCanonicalName in VS2008 SP1 Beta 1
                 }
 
-                string name;
                 try
                 {
-                    if (VSErr.Succeeded(hierarchy.GetCanonicalName(id, out name)))
+                    if (VSErr.Succeeded(hierarchy.GetCanonicalName(id, out string name)))
                     {
                         if (IsValidPath(name, true))
                         {
@@ -249,10 +246,7 @@ namespace Ankh.VS.Selection
         //[CLSCompliant(false)]
         static bool GetSccFiles(IVsHierarchy hierarchy, IVsSccProject2 sccProject, uint id, out string[] files, bool includeSpecial, bool includeNoScc, IDictionary<string, uint> map)
         {
-            int[] flags;
-            files = null;
-
-            if (!GetSccFiles(hierarchy, sccProject, id, out files, out flags, includeNoScc, map))
+            if (!GetSccFiles(hierarchy, sccProject, id, out files, out int[] flags, includeNoScc, map))
                 return false;
             else if (flags == null || sccProject == null || !includeSpecial)
                 return true;
@@ -291,8 +285,7 @@ namespace Ankh.VS.Selection
                 throw new ArgumentNullException("context");
 
             IVsSolution sol = context.GetService<IVsSolution>(typeof(SVsSolution));
-            string solutionDirectory, solutionFile, solutionUserOptions;
-            if (sol != null && VSErr.Succeeded(sol.GetSolutionInfo(out solutionDirectory, out solutionFile, out solutionUserOptions))
+            if (sol != null && VSErr.Succeeded(sol.GetSolutionInfo(out string solutionDirectory, out string solutionFile, out string solutionUserOptions))
                 && IsValidPath(solutionFile))
             {
                 return solutionFile;

--- a/src/Ankh.VS/Services/AnkhVSColor.cs
+++ b/src/Ankh.VS/Services/AnkhVSColor.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Drawing;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.VS.Services

--- a/src/Ankh.VS/Services/DiffMergeInstance.cs
+++ b/src/Ankh.VS/Services/DiffMergeInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Ankh.Commands;
+using Ankh.Services;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.VS/Services/GlobalCommandHook.cs
+++ b/src/Ankh.VS/Services/GlobalCommandHook.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Ankh.Services;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Ankh.VS/Services/InternalDiff.cs
+++ b/src/Ankh.VS/Services/InternalDiff.cs
@@ -158,13 +158,12 @@ namespace Ankh.VS.Services
             if (_ormw == null || _umw == null || _qmws == null)
                 return false;
 
-            int cookie;
 
             IVsWindowFrame frame = _ormw(args.TheirsFile, args.MineFile, args.BaseFile, args.MergedFile,
                                          Path.GetFileName(args.TheirsFile), Path.GetFileName(args.MineFile),
                                          Path.GetFileName(args.BaseFile), Path.GetFileName(args.MergedFile),
                                          args.TheirsTitle, args.MineTitle, args.BaseTitle, args.MergedTitle,
-                                         Guid.Empty.ToString(), null, null, out cookie);
+                                         Guid.Empty.ToString(), null, null, out int cookie);
 
             if (frame != null)
             {

--- a/src/Ankh.VS/SolutionExplorer/FileIconMapper.cs
+++ b/src/Ankh.VS/SolutionExplorer/FileIconMapper.cs
@@ -22,6 +22,7 @@ using System.IO;
 using Microsoft.VisualStudio;
 using System.Diagnostics;
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.VS.SolutionExplorer
 {

--- a/src/Ankh.VS/SolutionExplorer/StatusImageMapper.cs
+++ b/src/Ankh.VS/SolutionExplorer/StatusImageMapper.cs
@@ -53,8 +53,10 @@ namespace Ankh.VS.SolutionExplorer
 
                 Bitmap bitmap = (Bitmap)Image.FromStream(images, true);
 
-                ImageList imageList = new ImageList();
-                imageList.ImageSize = new Size(width, bitmap.Height);
+                ImageList imageList = new ImageList
+                {
+                    ImageSize = new Size(width, bitmap.Height)
+                };
                 bitmap.MakeTransparent(bitmap.GetPixel(0, 0));
 
                 imageList.Images.AddStrip(bitmap);

--- a/src/Ankh.VS/TextEditor/TextEditorFactory.cs
+++ b/src/Ankh.VS/TextEditor/TextEditorFactory.cs
@@ -17,8 +17,10 @@ namespace Ankh.VS.TextEditor
 
         public bool TryInstantiateIn(VSTextEditor editor, out IVSTextEditorImplementation implementation)
         {
-            TheVSTextEditor edit = new TheVSTextEditor();
-            edit.Dock = System.Windows.Forms.DockStyle.Fill;
+            TheVSTextEditor edit = new TheVSTextEditor
+            {
+                Dock = System.Windows.Forms.DockStyle.Fill
+            };
 
             implementation = edit;
 

--- a/src/Ankh.VS/TextEditor/TheVSTextEditor.cs
+++ b/src/Ankh.VS/TextEditor/TheVSTextEditor.cs
@@ -29,6 +29,7 @@ using Ankh.UI;
 
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using OLEConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
+using Ankh.Services;
 
 namespace Ankh.VS.TextEditor
 {

--- a/src/Ankh.VS/WebBrowser/AnkhWebBrowser.cs
+++ b/src/Ankh.VS/WebBrowser/AnkhWebBrowser.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Diagnostics;
 using Ankh.Configuration;
+using Ankh.Services;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Ankh.VS.WebBrowser

--- a/src/Ankh.VS/WpfServices/ServiceMethodResolver.cs
+++ b/src/Ankh.VS/WpfServices/ServiceMethodResolver.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Ankh.VS;
 
-namespace Ankh.WpfPackage.Services
+namespace Ankh.VS.WpfServices
 {
     [GlobalService(typeof(ILinqInterfaceDelegateService))]
     sealed class ServiceMethodResolver : AnkhService, ILinqInterfaceDelegateService
@@ -24,8 +24,7 @@ namespace Ankh.WpfPackage.Services
             
             Type type = typeof(TDelegate);
 
-            ParameterExpression[] args;
-            MethodCallExpression mce = GetMethodCall(fromInterface, method, ob, out args);
+            MethodCallExpression mce = GetMethodCall(fromInterface, method, ob, out ParameterExpression[] args);
 
             if (mce != null)
                 return Expression.Lambda<TDelegate>(mce, args).Compile();

--- a/src/Ankh.VS/WpfServices/ThemingService.cs
+++ b/src/Ankh.VS/WpfServices/ThemingService.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Ankh.UI;
 using Ankh.VS;
 using Ankh.ExtensionPoints.UI;
+using Ankh.Services;
 
 namespace Ankh.WpfPackage.Services
 {

--- a/src/Ankh.VS/WpfServices/ThreadedWaitService.cs
+++ b/src/Ankh.VS/WpfServices/ThreadedWaitService.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 
 using Ankh.UI;
+using Ankh.Services;
 
 namespace Ankh.WpfPackage.Services
 {

--- a/src/Ankh.VS/WpfServices/WpfEditorInfo.cs
+++ b/src/Ankh.VS/WpfServices/WpfEditorInfo.cs
@@ -8,9 +8,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Text.Formatting;
 
-using Ankh.VS;
-
-namespace Ankh.WpfPackage.Services
+namespace Ankh.VS.WpfServices
 {
     [GlobalService(typeof(IGetWpfEditorInfo))]
     sealed class WpfEditorInfoService : AnkhService, IGetWpfEditorInfo

--- a/src/Ankh/Commands/CheckForUpdates.cs
+++ b/src/Ankh/Commands/CheckForUpdates.cs
@@ -26,6 +26,7 @@ using Microsoft.Win32;
 using Ankh.Configuration;
 using Ankh.UI;
 using Ankh.UI.SccManagement;
+using Ankh.Services;
 
 
 /*****************************************************************

--- a/src/Ankh/Commands/ItemDelete.cs
+++ b/src/Ankh/Commands/ItemDelete.cs
@@ -25,6 +25,7 @@ using System.IO;
 using SharpSvn;
 using Ankh.Selection;
 using System.Runtime.InteropServices;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh/Commands/OpenFromSubversion.cs
+++ b/src/Ankh/Commands/OpenFromSubversion.cs
@@ -22,6 +22,7 @@ using SharpSvn;
 using System.IO;
 using Ankh.Scc;
 using System.Collections.Generic;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh/Commands/OpenInVisualStudio.cs
+++ b/src/Ankh/Commands/OpenInVisualStudio.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 using Ankh.UI;
 using Ankh.Scc;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh/Commands/OpenInXExplorer.cs
+++ b/src/Ankh/Commands/OpenInXExplorer.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio;
 using SharpSvn;
 using System.Runtime.InteropServices;
+using Ankh.Services;
 
 namespace Ankh.Commands
 {

--- a/src/Ankh/Services/AnkhClientPool.cs
+++ b/src/Ankh/Services/AnkhClientPool.cs
@@ -27,6 +27,7 @@ using Ankh.Scc;
 using Ankh.UI;
 using Ankh.VS;
 using Ankh.Configuration;
+using System.Linq;
 
 namespace Ankh.Services
 {
@@ -44,9 +45,11 @@ namespace Ankh.Services
         public AnkhClientPool(IAnkhServiceProvider context)
             : base(context)
         {
-            _syncher = new Control();
-            _syncher.Visible = false;
-            _syncher.Text = "AnkhSVN Synchronizer";
+            _syncher = new Control
+            {
+                Visible = false,
+                Text = "AnkhSVN Synchronizer"
+            };
             GC.KeepAlive(_syncher.Handle); // Ensure the window is created
         }
 
@@ -147,10 +150,12 @@ namespace Ankh.Services
         private void HookUI(AnkhSvnPoolClient client)
         {
             // Let SharpSvnUI handle login and SSL dialogs
-            SvnUIBindArgs bindArgs = new SvnUIBindArgs();
-            bindArgs.ParentWindow = new OwnerWrapper(DialogOwner);
-            bindArgs.UIService = UIService;
-            bindArgs.Synchronizer = _syncher;
+            SvnUIBindArgs bindArgs = new SvnUIBindArgs
+            {
+                ParentWindow = new OwnerWrapper(DialogOwner),
+                UIService = UIService,
+                Synchronizer = _syncher
+            };
 
             if (Config != null && Config.Instance.PreferPuttyAsSSH)
                 client.Configuration.SshOverride = SharpSvn.Implementation.SvnSshOverride.ForceSharpPlinkAfterConfig;
@@ -161,10 +166,12 @@ namespace Ankh.Services
         private void HookUI(AnkhSvnPoolRemoteSession client)
         {
             // Let SharpSvnUI handle login and SSL dialogs
-            SvnUIBindArgs bindArgs = new SvnUIBindArgs();
-            bindArgs.ParentWindow = new OwnerWrapper(DialogOwner);
-            bindArgs.UIService = UIService;
-            bindArgs.Synchronizer = _syncher;
+            SvnUIBindArgs bindArgs = new SvnUIBindArgs
+            {
+                ParentWindow = new OwnerWrapper(DialogOwner),
+                UIService = UIService,
+                Synchronizer = _syncher
+            };
 
             if (Config != null && Config.Instance.PreferPuttyAsSSH)
                 client.Configuration.SshOverride = SharpSvn.Implementation.SvnSshOverride.ForceSharpPlinkAfterConfig;
@@ -179,9 +186,7 @@ namespace Ankh.Services
 
         public bool ReturnClient(SvnPoolClient poolClient)
         {
-            AnkhSvnPoolClient pc = poolClient as AnkhSvnPoolClient;
-
-            if (pc != null && pc.ReturnCookie == _returnCookie)
+            if (poolClient is AnkhSvnPoolClient pc && pc.ReturnCookie == _returnCookie)
             {
                 Stack<SvnPoolClient> stack = pc.UIEnabled ? _uiClients : _clients;
 
@@ -282,8 +287,10 @@ namespace Ankh.Services
                 {
                     if (!parentOk || !sessionUri.AbsolutePath.StartsWith(reuse.SessionUri.AbsolutePath))
                     {
-                        SvnRemoteCommonArgs rca = new SvnRemoteCommonArgs();
-                        rca.ThrowOnError = false;
+                        SvnRemoteCommonArgs rca = new SvnRemoteCommonArgs
+                        {
+                            ThrowOnError = false
+                        };
 
                         if (!reuse.Reparent(sessionUri, rca))
                             reuse = null;
@@ -304,9 +311,7 @@ namespace Ankh.Services
 
         public bool ReturnClient(SvnPoolRemoteSession session)
         {
-            AnkhSvnPoolRemoteSession pc = session as AnkhSvnPoolRemoteSession;
-
-            if (pc != null && pc.ReturnCookie == _returnCookie && pc.SessionUri != null)
+            if (session is AnkhSvnPoolRemoteSession pc && pc.ReturnCookie == _returnCookie && pc.SessionUri != null)
             {
                 pc.ReturnTime = DateTime.Now;
 
@@ -353,7 +358,7 @@ namespace Ankh.Services
             {
                 DateTime now = DateTime.Now;
 
-                foreach (AnkhSvnPoolRemoteSession rs in _remoteSessions)
+                foreach (AnkhSvnPoolRemoteSession rs in _remoteSessions.Cast<AnkhSvnPoolRemoteSession>())
                 {
                     bool dispose = false;
                     switch (rs.SessionUri.Scheme)
@@ -390,7 +395,7 @@ namespace Ankh.Services
             }
 
             if (toDispose != null)
-                foreach (AnkhSvnPoolRemoteSession rs in toDispose)
+                foreach (AnkhSvnPoolRemoteSession rs in toDispose.Cast<AnkhSvnPoolRemoteSession>())
                 {
                     try
                     {
@@ -432,8 +437,7 @@ namespace Ankh.Services
                 if (string.IsNullOrEmpty(path))
                     return;
 
-                SvnClientAction action;
-                if (!_changes.TryGetValue(path, out action))
+                if (!_changes.TryGetValue(path, out SvnClientAction action))
                     _changes.Add(path, action = new SvnClientAction(path));
 
                 switch (e.Action)
@@ -471,15 +475,12 @@ namespace Ankh.Services
 
                     if (fp == null) // Non local operation
                         return;
-
-                    SvnClientAction action;
-
-                    if (!_changes.TryGetValue(fp, out action))
+                    if (!_changes.TryGetValue(fp, out _))
                         _changes.Add(fp, new SvnClientAction(fp));
 
                     if (!string.IsNullOrEmpty(item.MovedFrom))
                     {
-                        if (!_changes.TryGetValue(item.MovedFrom, out action))
+                        if (!_changes.TryGetValue(item.MovedFrom, out _))
                             _changes.Add(item.MovedFrom, new SvnClientAction(item.MovedFrom));
                     }
                 }
@@ -528,7 +529,7 @@ namespace Ankh.Services
         sealed class AnkhSvnPoolWorkingCopyClient : SvnWorkingCopyClient
         {
             readonly SortedDictionary<string, SvnClientAction> _changes = new SortedDictionary<string, SvnClientAction>(StringComparer.OrdinalIgnoreCase);
-            AnkhClientPool _pool;
+            readonly AnkhClientPool _pool;
 
             public AnkhSvnPoolWorkingCopyClient(AnkhClientPool pool)
             {
@@ -541,8 +542,7 @@ namespace Ankh.Services
 
                 string path = e.FullPath;
 
-                SvnClientAction action;
-                if (!_changes.TryGetValue(path, out action))
+                if (!_changes.TryGetValue(path, out SvnClientAction action))
                     _changes.Add(path, action = new SvnClientAction(path));
 
                 switch (e.Action)
@@ -644,14 +644,11 @@ namespace Ankh.Services
 
     sealed class OwnerWrapper : IWin32Window
     {
-        IAnkhDialogOwner _owner;
+        readonly IAnkhDialogOwner _owner;
 
         public OwnerWrapper(IAnkhDialogOwner owner)
         {
-            if (owner == null)
-                throw new ArgumentNullException("owner");
-
-            _owner = owner;
+            _owner = owner ?? throw new ArgumentNullException("owner");
         }
 
         public IntPtr Handle
@@ -662,9 +659,7 @@ namespace Ankh.Services
 
                 if (window != null)
                 {
-                    ISynchronizeInvoke invoker = window as ISynchronizeInvoke;
-
-                    if (invoker != null && invoker.InvokeRequired && Control.CheckForIllegalCrossThreadCalls)
+                    if (window is ISynchronizeInvoke invoker && invoker.InvokeRequired && Control.CheckForIllegalCrossThreadCalls)
                     {
                         Control.CheckForIllegalCrossThreadCalls = false;
                         try

--- a/src/Ankh/Services/AnkhDiff.cs
+++ b/src/Ankh/Services/AnkhDiff.cs
@@ -83,17 +83,17 @@ namespace Ankh.Services
                 return internalDiff.RunDiff(args);
             }
 
-            string program;
-            string arguments;
-            if (!Substitute(diffApp, args, DiffToolMode.Diff, out program, out arguments)
+            if (!Substitute(diffApp, args, DiffToolMode.Diff, out string program, out string arguments)
                 || !File.Exists(program))
             {
                 new AnkhMessageBox(Context).Show(string.Format("Can't find diff program '{0}'", program ?? diffApp));
                 return false;
             }
 
-            Process p = new Process();
-            p.StartInfo = new ProcessStartInfo(program, arguments);
+            Process p = new Process
+            {
+                StartInfo = new ProcessStartInfo(program, arguments)
+            };
 
             string mergedFile = args.MineFile;
 
@@ -113,11 +113,8 @@ namespace Ankh.Services
             }
             finally
             {
-                if (!started)
-                {
-                    if (monitor != null)
-                        monitor.Dispose();
-                }
+                if (!started && monitor != null)
+                    monitor.Dispose();
             }
         }
 
@@ -175,17 +172,17 @@ namespace Ankh.Services
                 return false;
             }
 
-            string program;
-            string arguments;
-            if (!Substitute(mergeApp, args, DiffToolMode.Merge, out program, out arguments)
+            if (!Substitute(mergeApp, args, DiffToolMode.Merge, out string program, out string arguments)
                 || !File.Exists(program))
             {
                 new AnkhMessageBox(Context).Show(string.Format("Can't find merge program '{0}'", program ?? mergeApp));
                 return false;
             }
 
-            Process p = new Process();
-            p.StartInfo = new ProcessStartInfo(program, arguments);
+            Process p = new Process
+            {
+                StartInfo = new ProcessStartInfo(program, arguments)
+            };
 
             string mergedFile = args.MergedFile;
 
@@ -205,11 +202,8 @@ namespace Ankh.Services
             }
             finally
             {
-                if (!started)
-                {
-                    if (monitor != null)
-                        monitor.Dispose();
-                }
+                if (!started && monitor != null)
+                    monitor.Dispose();
             }
         }
 
@@ -244,16 +238,16 @@ namespace Ankh.Services
                 return false;
             }
 
-            string program;
-            string arguments;
-            if (!Substitute(diffApp, args, DiffToolMode.Patch, out program, out arguments))
+            if (!Substitute(diffApp, args, DiffToolMode.Patch, out string program, out string arguments))
             {
                 new AnkhMessageBox(Context).Show(string.Format("Can't find patch program '{0}'", program));
                 return false;
             }
 
-            Process p = new Process();
-            p.StartInfo = new ProcessStartInfo(program, arguments);
+            Process p = new Process
+            {
+                StartInfo = new ProcessStartInfo(program, arguments)
+            };
 
             string applyTo = args.ApplyTo;
 
@@ -273,11 +267,8 @@ namespace Ankh.Services
             }
             finally
             {
-                if (!started)
-                {
-                    if (monitor != null)
-                        monitor.Dispose();
-                }
+                if (!started && monitor != null)
+                    monitor.Dispose();
             }
         }
 
@@ -291,9 +282,11 @@ namespace Ankh.Services
             SvnUriTarget copiedFrom = null;
             using (SvnClient client = GetService<ISvnClientPool>().GetNoUIClient())
             {
-                SvnInfoArgs ia = new SvnInfoArgs();
-                ia.ThrowOnError = false;
-                ia.Depth = SvnDepth.Empty;
+                SvnInfoArgs ia = new SvnInfoArgs
+                {
+                    ThrowOnError = false,
+                    Depth = SvnDepth.Empty
+                };
 
                 client.Info(item.FullPath, ia,
                     delegate(object sender, SvnInfoEventArgs ee)
@@ -313,7 +306,7 @@ namespace Ankh.Services
             readonly string _toMonitor;
             readonly bool _monitorDir;
             IAnkhOpenDocumentTracker _odt;
-            int[] _resolvedExitCodes;
+            readonly int[] _resolvedExitCodes;
 
             public DiffToolMonitor(IAnkhServiceProvider context, string monitor, bool monitorDir, int[] resolvedExitCodes)
                 : base(context)
@@ -381,11 +374,12 @@ namespace Ankh.Services
                     }
                 }
 
-                if (_odt != null)
+                if (_odt == null)
                 {
-                    _odt.IgnoreChanges(_toMonitor, false);
-                    _odt = null;
+                    return;
                 }
+                _odt.IgnoreChanges(_toMonitor, false);
+                _odt = null;
             }
 
             private void MarkResolved()
@@ -408,7 +402,6 @@ namespace Ankh.Services
 
             void OnExited(object sender, EventArgs e)
             {
-                Process process = sender as Process;
                 IAnkhCommandService cmd = GetService<IAnkhCommandService>();
 
                 if (cmd != null)
@@ -416,8 +409,8 @@ namespace Ankh.Services
                 else
                     Dispose();
 
-                if (process != null && _resolvedExitCodes != null)
-                    foreach(int ec in _resolvedExitCodes)
+                if (sender is Process process && _resolvedExitCodes != null)
+                    foreach (int ec in _resolvedExitCodes)
                     {
                         if (ec == process.ExitCode)
                         {
@@ -428,20 +421,23 @@ namespace Ankh.Services
 
                 IFileStatusMonitor m = GetService<IFileStatusMonitor>();
 
-                if (m != null)
+                if (m == null)
                 {
-                    m.ScheduleSvnStatus(_toMonitor);
+                    return;
                 }
+                m.ScheduleSvnStatus(_toMonitor);
             }
 
             public int DirectoryChanged(string pszDirectory)
             {
                 ISvnStatusCache fsc = GetService<ISvnStatusCache>();
 
-                if (fsc != null)
+                if (fsc == null)
                 {
-                    fsc.MarkDirtyRecursive(SvnTools.GetNormalizedFullPath(pszDirectory));
+                    return VSErr.S_OK;
                 }
+
+                fsc.MarkDirtyRecursive(SvnTools.GetNormalizedFullPath(pszDirectory));
 
                 return VSErr.S_OK;
             }
@@ -459,8 +455,7 @@ namespace Ankh.Services
 
                         if (m != null)
                         {
-                            bool isDirty;
-                            m.ExternallyChanged(_toMonitor, out isDirty);
+                            m.ExternallyChanged(_toMonitor, out bool isDirty);
 
                             if (isDirty)
                                 Dispose();
@@ -647,8 +642,7 @@ namespace Ankh.Services
 
                         foreach (string s in value.Split(','))
                         {
-                            int i;
-                            if (int.TryParse(s.Trim(), out i))
+                            if (int.TryParse(s.Trim(), out int i))
                             {
                                 intVals.Add(i);
                             }
@@ -774,8 +768,7 @@ namespace Ankh.Services
                         IVsSolution sol = GetService<IVsSolution>(typeof(SVsSolution));
                         if (sol == null)
                             return false;
-                        object val;
-                        if (VSErr.Succeeded(sol.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out val)))
+                        if (VSErr.Succeeded(sol.GetProperty((int)__VSSPROPID.VSSPROPID_InstallDirectory, out object val)))
                             value = val as string;
                         return true;
                     default:
@@ -867,8 +860,10 @@ namespace Ankh.Services
             ProgressRunnerResult r = GetService<IProgressRunner>().RunModal(ServiceStrings.RetrievingFileForComparison,
                 delegate(object sender, ProgressWorkerArgs aa)
                 {
-                    SvnWriteArgs wa = new SvnWriteArgs();
-                    wa.Revision = revision;
+                    SvnWriteArgs wa = new SvnWriteArgs
+                    {
+                        Revision = revision
+                    };
 
                     using (Stream s = File.Create(file))
                         aa.Client.Write(target.FullPath, s, wa);
@@ -896,8 +891,10 @@ namespace Ankh.Services
             ProgressRunnerResult r = GetService<IProgressRunner>().RunModal(ServiceStrings.RetrievingFileForComparison,
                 delegate(object sender, ProgressWorkerArgs aa)
                 {
-                    SvnWriteArgs wa = new SvnWriteArgs();
-                    wa.Revision = revision;
+                    SvnWriteArgs wa = new SvnWriteArgs
+                    {
+                        Revision = revision
+                    };
                     wa.AddExpectedError(SvnErrorCode.SVN_ERR_CLIENT_UNRELATED_RESOURCES);
 
                     using (Stream s = File.Create(file))
@@ -938,9 +935,12 @@ namespace Ankh.Services
                 ProgressRunnerResult r = Context.GetService<IProgressRunner>().RunModal(ServiceStrings.RetrievingMultipleVersionsOfFile,
                     delegate(object sender, ProgressWorkerArgs e)
                     {
-                        SvnFileVersionsArgs ea = new SvnFileVersionsArgs();
-                        ea.Start = from;
-                        ea.End = to;
+                        SvnFileVersionsArgs ea = new SvnFileVersionsArgs
+                        {
+                            Start = from,
+                            End = to
+                        };
+
                         ea.AddExpectedError(SvnErrorCode.SVN_ERR_UNSUPPORTED_FEATURE); // Github
 
                         e.Client.FileVersions(target, ea,

--- a/src/Ankh/Services/ConfigService.cs
+++ b/src/Ankh/Services/ConfigService.cs
@@ -23,6 +23,7 @@ using Microsoft.Win32;
 
 using Ankh.UI;
 using Ankh.VS;
+using Ankh.Services;
 
 namespace Ankh.Configuration
 {

--- a/src/Ankh/Services/SolutionSettings.cs
+++ b/src/Ankh/Services/SolutionSettings.cs
@@ -28,6 +28,7 @@ using Ankh.Scc;
 using Ankh.Selection;
 using Ankh.UI;
 using Ankh.VS;
+using Ankh.Services;
 
 namespace Ankh.Settings
 {


### PR DESCRIPTION
**Description**

This PR addresses a couple of UI layout issues reported when using AnkhSVN with newer Visual Studio versions, particularly Visual Studio 2026.

**Changes**

- Fix Commit dialog layout
- Updates the Pending Changes list to fill its container correctly.
- Allows the commit message field to resize with the dialog.
- Fixes the distorted/clipped Commit window layout reported in #81, including Visual Studio 2026 Update 3.
- Fix Revert dialog buttons being clipped
- Adds a minimum size to PendingChangeSelector.
- Prevents a previously saved window size from restoring the dialog too small for the OK and Cancel buttons to remain visible.
- Addresses the behavior reported in #85 on newer Visual Studio 2022/2026 builds.

These changes are intentionally small and localized to the affected dialogs rather than changing AnkhSVN's shared window-placement behavior globally.

Related Issues
#81
#85

Tested with the Visual Studio 2026-compatible build of AnkhSVN.